### PR TITLE
Remove dead link from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ $ ember generate fragment foo someAttr:string anotherAttr:boolean
 
 Which will create the module `app/models/foo.js` which exports a `Fragment` class with the given attributes.
 
-You might also want to take a look at [FEDITOR's Ember Data model generator](http://feditor.tech/content/gist/6478b5134893399879c0), which can generate `Model` and `Fragment` classes based on your API's JSON response.
-
 ## Example
 
 ```javascript


### PR DESCRIPTION
There is a link in the README to a online code generator that now links to an unrelated page. This removes that link.